### PR TITLE
Clarify --component flag refers to module name

### DIFF
--- a/INTEGRATION.md
+++ b/INTEGRATION.md
@@ -295,11 +295,12 @@ npm install @convex-dev/static-hosting
 - You must create `convex/http.ts` and register routes
 - Run `npx convex dev` to regenerate types after adding http.ts
 
-### Component name mismatch
-Default component name is `staticHosting`. If you named your file differently or used a different component name in config, specify it:
+### `--component` is the module name, not the component name
+Despite its name, `--component <name>` refers to the **Convex module** where you exposed the upload API (i.e. `convex/<name>.ts`), not the component name registered in `convex.config.ts`. If you put the `exposeUploadApi(...)` re-exports in `convex/myCustomName.ts`, pass:
 ```bash
 npx @convex-dev/static-hosting upload --component myCustomName
 ```
+Default is `staticHosting` (i.e. `convex/staticHosting.ts`).
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ npx @convex-dev/static-hosting upload [options]
 
 Options:
   -d, --dist <path>           Path to dist directory (default: ./dist)
-  -c, --component <name>      Convex component name (default: staticHosting)
+  -c, --component <module>    Module name where upload API is exposed — i.e.
+                              convex/<module>.ts (default: staticHosting)
       --prod                  Deploy to production Convex deployment
       --dev                   Deploy to dev deployment (default)
   -b, --build                 Run 'npm run build' with correct VITE_CONVEX_URL
@@ -203,7 +204,8 @@ npx @convex-dev/static-hosting deploy [options]
 
 Options:
   -d, --dist <path>           Path to dist directory (default: ./dist)
-  -c, --component <name>      Convex component name (default: staticHosting)
+  -c, --component <module>    Module name where upload API is exposed — i.e.
+                              convex/<module>.ts (default: staticHosting)
       --skip-build            Skip the build step (use existing dist)
       --skip-convex           Skip Convex backend deployment
   -h, --help                  Show help

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -65,7 +65,9 @@ Minimizes the inconsistency window between backend and frontend updates.
 
 Options:
   -d, --dist <path>           Path to dist directory (default: ./dist)
-  -c, --component <name>      Convex component name (default: staticHosting)
+  -c, --component <module>    Module name where upload API is exposed — i.e.
+                              convex/<module>.ts (default: staticHosting). Not
+                              the registered component name from convex.config.ts.
       --skip-build            Skip the build step (use existing dist)
       --skip-convex           Skip Convex backend deployment
       --cdn                   Upload non-HTML assets to convex-fs CDN

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -161,7 +161,7 @@ npx @convex-dev/static-hosting upload [options]
 
 Options:
   -d, --dist <path>        Path to dist directory (default: ./dist)
-  -c, --component <name>   Convex component name (default: staticHosting)
+  -c, --component <module> Module name where upload API is exposed — i.e. convex/<module>.ts (default: staticHosting)
       --prod               Deploy to production Convex deployment
       --dev                Deploy to dev deployment (default)
   -b, --build              Run 'npm run build' with correct VITE_CONVEX_URL

--- a/src/cli/upload.ts
+++ b/src/cli/upload.ts
@@ -7,7 +7,7 @@
  *
  * Options:
  *   --dist <path>            Path to dist directory (default: ./dist)
- *   --component <name>       Convex component with upload functions (default: staticHosting)
+ *   --component <module>     Module name where upload API is exposed — i.e. convex/<module>.ts (default: staticHosting)
  *   --prod                   Deploy to production deployment
  *   --help                   Show help
  */
@@ -102,7 +102,9 @@ Upload static files from a dist directory to Convex storage.
 
 Options:
   -d, --dist <path>           Path to dist directory (default: ./dist)
-  -c, --component <name>      Convex component with upload functions (default: staticHosting)
+  -c, --component <module>    Module name where upload API is exposed — i.e.
+                              convex/<module>.ts (default: staticHosting). Not
+                              the registered component name from convex.config.ts.
       --prod                  Deploy to production deployment
   -b, --build                 Run 'npm run build' with correct VITE_CONVEX_URL before uploading
       --cdn                   Upload non-HTML assets to convex-fs CDN instead of Convex storage


### PR DESCRIPTION
## Summary

The `--component <name>` flag in the `upload` and `deploy` CLIs takes a **Convex module path prefix** (i.e. `convex/<name>.ts` — the file where you re-export `exposeUploadApi(...)`), not the component name registered in `convex.config.ts`. The previous help text and docs said "Convex component name", which is misleading when those names differ — e.g. component registered as `selfHosting` but upload API exposed in `convex/staticHosting.ts`.

This PR is doc-only:
- Updates `--component` help text in `upload`, `deploy`, and the `init`-emitted CLI Reference
- Updates README CLI options blocks for both commands
- Renames the `INTEGRATION.md` troubleshooting section and rewrites it to call out the misnomer explicitly

No code or default-value changes.

## Test plan

- [x] Updated help text reads cleanly when wrapped in the help output
- [ ] Skim rendered README/INTEGRATION on GitHub