### PR TITLE
fix(client): serve /foo/index.html for /foo and /foo/ requests

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -218,7 +218,17 @@ export function registerStaticRoutes(
 
     let asset: AssetDoc = await ctx.runQuery(component.lib.getByPath, { path });
 
-    // SPA fallback: if not found and no file extension, serve index.html
+    // Directory-index fallback: serve /foo/index.html when /foo or /foo/ is
+    // requested. Supports frameworks like Next.js `output: 'export'` that emit
+    // directory-based static trees (e.g. `out/about/index.html`).
+    if (!asset && !hasFileExtension(path)) {
+      const indexPath = path.endsWith("/")
+        ? `${path}index.html`
+        : `${path}/index.html`;
+      asset = await ctx.runQuery(component.lib.getByPath, { path: indexPath });
+    }
+
+    // SPA fallback: if still not found and no file extension, serve index.html
     if (!asset && spaFallback && !hasFileExtension(path)) {
       asset = await ctx.runQuery(component.lib.getByPath, {
         path: "/index.html",


### PR DESCRIPTION
## Problem

When a static bundle is laid out as a directory tree, the only stored asset for a route is `/<route>/index.html`. Requests for `/<route>` or `/<route>/` miss the exact-path lookup, fall through to the SPA fallback, and serve the root `/index.html` instead of the route's own page.

This happens with any framework that emits directory-based static exports — most notably **Next.js with `output: 'export'`**, which produces `out/about/index.html`, `out/foo/index.html`, etc.

### Repro

```sh
# Next.js project with output: 'export' and trailingSlash: true
npm run build   # produces out/g/index.html and out/edit/index.html
npx @convex-dev/static-hosting upload --build --prod
```

After deploy:

```
GET /          -> serves /index.html  ✓
GET /g/index.html -> serves /g/index.html  ✓
GET /g         -> serves /index.html  ✗  (SPA fallback fires)
GET /g/        -> serves /index.html  ✗  (SPA fallback fires)
```

Users hit this whenever they share a deep link to a Next.js export route. They see the homepage instead of the intended page.

## Fix

Add a directory-index fallback step between the exact-path lookup and the SPA fallback. If the request has no file extension and `/<path>/index.html` exists, serve that. Otherwise the SPA fallback runs unchanged.

```ts
// Directory-index fallback: serve /foo/index.html when /foo or /foo/ is
// requested. Supports frameworks like Next.js `output: 'export'` that emit
// directory-based static trees (e.g. `out/about/index.html`).
if (!asset && !hasFileExtension(path)) {
  const indexPath = path.endsWith("/")
    ? \`\${path}index.html\`
    : \`\${path}/index.html\`;
  asset = await ctx.runQuery(component.lib.getByPath, { path: indexPath });
}
```

## Compatibility

Non-breaking. For Vite/CRA-style flat outputs the directory-index lookup misses and the SPA fallback runs as before. Existing test suite passes unchanged.

## Notes

This makes the component usable for Next.js App Router static exports — currently the only workaround is to consolidate all routing into a single root page and dispatch client-side off query params, which loses the framework's filesystem routing entirely.

Happy to add an HTTP-level test via \`t.fetch()\` in \`example/convex/staticHosting.test.ts\` if you'd like — left it out of this PR to keep the change minimal, but the manual repro above is reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)