### PR TITLE
[codex] Add static hosting video thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 A Convex component that enables hosting static React/Vite apps using Convex
 HTTP actions and file storage. No external hosting provider required!
 
+[![Share your slop with the Static Hosting Component!](https://thumbs.video-to-markdown.com/d5a10c30.jpg)](https://youtu.be/RNjTys_2OX4)
+
 ## Quick Start
 
 ### Automated Setup (Recommended)


### PR DESCRIPTION
## Summary

Adds the Static Hosting walkthrough video thumbnail near the top of the README, linking to the YouTube video.

## Impact

Readers can find the new Static Hosting component video directly from the package README.

## Validation

- Ran `git diff --check -- README.md`
- Verified the thumbnail URL and YouTube URL earlier in the session

## Notes

This PR only includes the README change. The untracked `AGENTS.md` file in the local worktree was left out.
