### PR TITLE
improve docs based on feedback, and fall back to old component name

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -123,6 +123,17 @@ published 0.2.x package.
 
 ### 2. Choose a routing mode
 
+This choice also decides how much downtime the cutover can cost you, so make it
+before, not after, the storage work. If the app serves auth, webhooks, or a
+public API from the root and you keep the old 0.1.x instance name, **Option B
+plus the kept instance name is the zero-downtime path**: the app-side handler
+keeps serving the inherited v1 files from app storage until the first 0.2.x
+upload replaces the manifest, so there is no setup page and no 503 window during
+the switch. Component-owned root mode (Option A) cannot do this, because the
+component cannot read the inherited app-storage blobs and shows the setup page
+until the first upload. See [step 4](#4-check-scripts-and-component-names) for
+the instance-name mechanics.
+
 #### Option A: component-owned root (recommended)
 
 Use this when app-owned HTTP endpoints can move from `/route` to `/api/route`,
@@ -138,7 +149,7 @@ Replace the old component registration with:
 ```ts
 // convex/convex.config.ts
 import { defineApp } from "convex/server";
-import staticHosting from "@convex-dev/static-hosting/convex.config.js";
+import staticHosting from "@convex-dev/static-hosting/convex.config";
 
 // Routes from convex/http.ts are now served below /api.
 const app = defineApp({ httpPrefix: "/api" });
@@ -163,7 +174,7 @@ action serves the files after an internal component lookup.
 ```ts
 // convex/convex.config.ts
 import { defineApp } from "convex/server";
-import staticHosting from "@convex-dev/static-hosting/convex.config.js";
+import staticHosting from "@convex-dev/static-hosting/convex.config";
 
 const app = defineApp();
 app.use(staticHosting); // no httpPrefix: the app owns HTTP routing
@@ -191,6 +202,12 @@ export default http;
 Exact app routes take precedence over the static catch-all. This mode preserves
 their URLs, but an uncached static request adds an internal query and storage
 fetch compared with component-owned serving.
+
+If you also keep the 0.1.x instance name (see
+[step 4](#4-check-scripts-and-component-names)), this mode has no downtime
+window: the app-side handler serves the inherited v1 files from app storage
+until the first 0.2.x upload atomically replaces the manifest. This is the
+recommended combination for apps whose root URLs cannot move.
 
 ### 3. Remove the old upload facade
 
@@ -295,6 +312,28 @@ The commands below show the default v2 instance name, `staticHosting`. Replace
 it with the exact chosen v2 name, such as `selfHosting` or `staticHostingV2`, in
 every `--component` flag and generated `components.*` reference.
 
+> **Keeping a custom name has an ongoing cost.** Every `deploy` and `upload`
+> command needs the matching `--component` flag for as long as the name differs
+> from the default. Forgetting it is not silent: the CLI resolves the component
+> by name before uploading, so an unknown name stops with
+> `Could not reach component "..."` rather than writing to the wrong place. As a
+> convenience, when you rely on the default and only the legacy `selfHosting`
+> instance exists, the CLI finds it automatically and prints a warning
+> suggesting you rename to `staticHosting`. A mistyped custom name still errors,
+> so a typo cannot quietly publish to an empty component.
+
+If you would rather not carry the flag indefinitely, keep the custom name only
+long enough to complete the zero-downtime cutover, then rename to the default
+`staticHosting` as a separate, non-urgent step. Renaming in place would create a
+fresh empty component, so do it the same way as the staged cutover: mount both
+the current instance and a new `staticHosting` instance, upload the assets to
+`staticHosting`, switch serving to `components.staticHosting`, verify, and only
+then remove the old mount. Because the new instance is fully populated before
+serving moves to it, that second switch also has no downtime. See
+[Staged cutover](#staged-cutover) for the two-instance mechanics; the only
+difference is that both mounts are 0.2.x, so no `static-hosting-legacy` alias is
+involved.
+
 ### 5. Regenerate and test on a development deployment
 
 Push the new component definition and regenerate `components.*` references:
@@ -342,7 +381,10 @@ Test all of the following on the development `*.convex.site` URL:
 - If the app uses Convex Auth at the root, both
   `/.well-known/openid-configuration` and `/.well-known/jwks.json` still return
   JSON successfully.
-- Hashed assets have long-lived immutable caching, while HTML revalidates.
+- Hashed assets return `Cache-Control: public, max-age=31536000, immutable` and
+  HTML returns `public, max-age=0, must-revalidate`. The long `max-age` is the
+  load-bearing part; a CDN or proxy in front of the deployment may drop the
+  `immutable` directive, which is harmless.
 - If used, the update banner detects a later upload.
 
 ### 6. Deploy production
@@ -424,8 +466,28 @@ export before migrating rather than accepting a truncated cleanup manifest.
 
 ### Audit app storage for older v1 orphans
 
-The Convex dashboard can export the app's `_storage` metadata. An agent can also
-add this temporary paginated internal query before migration:
+The simplest path is `npx convex data`, which reads `_storage` metadata directly
+with no code deploy:
+
+```bash
+npx convex data _storage --prod --limit 1000 --order asc \
+  > ~/static-hosting-v1-storage.json
+```
+
+This is read-only, so it works even when the repository carries unshipped work
+that a temporary query would force into production. Raise `--limit` above the
+row count `npx convex data` reports for `_storage`, and if the table is larger
+than one `data` page can return, fall back to the paginated query below.
+
+> **This lists the whole `_storage` table, not just static-hosting files.** If
+> the app uses file storage for anything else — user uploads, exports,
+> attachments, other components' blobs — those rows appear here too, and nothing
+> in the metadata marks a row as static hosting. Treat this output as an
+> inventory to classify, never as a delete list. The classification and approval
+> steps below are mandatory before removing anything.
+
+For a `_storage` table larger than one `npx convex data` page, add this
+temporary paginated internal query before migration and walk every page:
 
 ```ts
 // convex/auditStaticHostingStorage.ts
@@ -467,8 +529,11 @@ npx convex run auditStaticHostingStorage:listAppStorage \
 Repeat with each returned `continueCursor` until `isDone` is true. Remove the
 temporary query after the inventory is safely stored.
 
-The `_storage` table can also contain uploads owned by the rest of the app. The
-IDs from the current v1 manifest are definitely static-hosting files. Classify
+The `_storage` table can also contain uploads owned by the rest of the app —
+user-uploaded images, generated exports, attachments, or blobs written by other
+components all share this one table, and none of them carry a marker
+distinguishing them from static-hosting assets. The IDs from the current v1
+manifest are the only rows that are definitely static-hosting files. Classify
 additional historical candidates using deployment timing, content type, size,
 hash matches to known static assets, and, when necessary, the blob contents. In
 the rehearsal, duplicate hashes and adjacent creation times tied the older CSS
@@ -569,7 +634,7 @@ temporary prefix:
 ```ts
 // convex/convex.config.ts
 import { defineApp } from "convex/server";
-import staticHosting from "@convex-dev/static-hosting/convex.config.js";
+import staticHosting from "@convex-dev/static-hosting/convex.config";
 import staticHostingLegacy from "static-hosting-legacy/convex.config.js";
 
 const app = defineApp();

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ npm install @convex-dev/static-hosting
 
 ```ts
 import { defineApp } from "convex/server";
-import staticHosting from "@convex-dev/static-hosting/convex.config.js";
+import staticHosting from "@convex-dev/static-hosting/convex.config";
 
 // Your own HTTP endpoints (convex/http.ts) are served under /api so the
 // static site can own the root.
@@ -103,7 +103,7 @@ existing router.
 
 ```ts
 import { defineApp } from "convex/server";
-import staticHosting from "@convex-dev/static-hosting/convex.config.js";
+import staticHosting from "@convex-dev/static-hosting/convex.config";
 
 const app = defineApp();
 app.use(staticHosting); // no httpPrefix

--- a/example/convex/convex.config.ts
+++ b/example/convex/convex.config.ts
@@ -1,5 +1,5 @@
 import { defineApp } from "convex/server";
-import staticHosting from "@convex-dev/static-hosting/convex.config.js";
+import staticHosting from "@convex-dev/static-hosting/convex.config";
 
 const app = defineApp({ httpPrefix: "/api" });
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -23,7 +23,10 @@ export function runConvex(args: string[]): string {
   }).trim();
 }
 
-export function runConvexAsync(args: string[]): Promise<string> {
+export function runConvexAsync(
+  args: string[],
+  options: { quiet?: boolean } = {},
+): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile(
       process.execPath,
@@ -31,7 +34,12 @@ export function runConvexAsync(args: string[]): Promise<string> {
       { encoding: "utf-8" },
       (error, stdout, stderr) => {
         if (error) {
-          console.error("Convex run failed:", stderr || stdout);
+          // Callers that probe optional components (e.g. resolving a legacy
+          // instance name) pass quiet so an expected miss isn't logged as a
+          // failure.
+          if (!options.quiet) {
+            console.error("Convex run failed:", stderr || stdout);
+          }
           reject(error);
           return;
         }

--- a/src/cli/componentName.test.ts
+++ b/src/cli/componentName.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   componentNameCandidates,
   DEFAULT_COMPONENT_NAME,
+  isLegacyAutoDetected,
   LEGACY_COMPONENT_NAME,
   legacyComponentNameWarning,
 } from "./componentName.js";
@@ -24,6 +25,22 @@ describe("component name resolution", () => {
     expect(componentNameCandidates("staticHostingV2")).toEqual([
       "staticHostingV2",
     ]);
+  });
+
+  test("only an auto-detected legacy fallback warrants a warning", () => {
+    // Relied on the default, fell back to legacy: warn.
+    expect(
+      isLegacyAutoDetected(DEFAULT_COMPONENT_NAME, LEGACY_COMPONENT_NAME),
+    ).toBe(true);
+    // Explicitly requested the legacy name (e.g. deploy forwarding it to the
+    // upload subprocess): stay silent so a single command warns at most once.
+    expect(
+      isLegacyAutoDetected(LEGACY_COMPONENT_NAME, LEGACY_COMPONENT_NAME),
+    ).toBe(false);
+    // Resolved the default: nothing to warn about.
+    expect(
+      isLegacyAutoDetected(DEFAULT_COMPONENT_NAME, DEFAULT_COMPONENT_NAME),
+    ).toBe(false);
   });
 
   test("the legacy warning names the instance and the current default", () => {

--- a/src/cli/componentName.test.ts
+++ b/src/cli/componentName.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import {
+  componentNameCandidates,
+  DEFAULT_COMPONENT_NAME,
+  LEGACY_COMPONENT_NAME,
+  legacyComponentNameWarning,
+} from "./componentName.js";
+
+describe("component name resolution", () => {
+  test("default name also probes the legacy name", () => {
+    expect(componentNameCandidates(DEFAULT_COMPONENT_NAME)).toEqual([
+      DEFAULT_COMPONENT_NAME,
+      LEGACY_COMPONENT_NAME,
+    ]);
+  });
+
+  test("legacy name is used verbatim without expanding", () => {
+    expect(componentNameCandidates(LEGACY_COMPONENT_NAME)).toEqual([
+      LEGACY_COMPONENT_NAME,
+    ]);
+  });
+
+  test("a custom name is never redirected to another instance", () => {
+    expect(componentNameCandidates("staticHostingV2")).toEqual([
+      "staticHostingV2",
+    ]);
+  });
+
+  test("the legacy warning names the instance and the current default", () => {
+    const warning = legacyComponentNameWarning(LEGACY_COMPONENT_NAME);
+    expect(warning).toContain(LEGACY_COMPONENT_NAME);
+    expect(warning).toContain(DEFAULT_COMPONENT_NAME);
+  });
+});

--- a/src/cli/componentName.ts
+++ b/src/cli/componentName.ts
@@ -23,6 +23,22 @@ export function componentNameCandidates(requested: string): string[] {
   return [DEFAULT_COMPONENT_NAME, LEGACY_COMPONENT_NAME];
 }
 
+/**
+ * Whether resolving `requested` to `resolved` was a legacy-name auto-detection
+ * worth warning about. Only true when the caller relied on the default and we
+ * fell back to the legacy name — an explicitly requested name (including a
+ * command forwarding the resolved name to a subprocess) is left silent so a
+ * single `deploy` warns at most once.
+ */
+export function isLegacyAutoDetected(
+  requested: string,
+  resolved: string,
+): boolean {
+  return (
+    requested === DEFAULT_COMPONENT_NAME && resolved === LEGACY_COMPONENT_NAME
+  );
+}
+
 /** Warning shown once when a command resolves to the legacy instance name. */
 export function legacyComponentNameWarning(name: string): string {
   return (

--- a/src/cli/componentName.ts
+++ b/src/cli/componentName.ts
@@ -1,0 +1,35 @@
+/**
+ * Component instance name resolution shared by the deploy and upload commands.
+ *
+ * 0.1.x mounted the component as `selfHosting`; 0.2.x defaults to
+ * `staticHosting`. A same-name migration that kept the legacy instance name
+ * would otherwise force `--component selfHosting` on every command, and the
+ * penalty for forgetting it used to be a confusing "component not found" bail.
+ * Instead the CLI probes both names when the caller relied on the default, and
+ * warns when it lands on the legacy one.
+ */
+export const DEFAULT_COMPONENT_NAME = "staticHosting";
+export const LEGACY_COMPONENT_NAME = "selfHosting";
+
+/**
+ * Instance names to probe, in order, for a requested name.
+ *
+ * Only the default request expands to include the legacy name. Any other
+ * requested name is used verbatim: an explicit custom name must never be
+ * silently redirected to a different instance.
+ */
+export function componentNameCandidates(requested: string): string[] {
+  if (requested !== DEFAULT_COMPONENT_NAME) return [requested];
+  return [DEFAULT_COMPONENT_NAME, LEGACY_COMPONENT_NAME];
+}
+
+/** Warning shown once when a command resolves to the legacy instance name. */
+export function legacyComponentNameWarning(name: string): string {
+  return (
+    `⚠️  Using the legacy component name "${name}" (the 0.1.x default; the ` +
+    `current default is "${DEFAULT_COMPONENT_NAME}").\n` +
+    `   This keeps working, but every deploy and upload has to keep passing ` +
+    `--component ${name}. To drop the flag, rename the instance to ` +
+    `"${DEFAULT_COMPONENT_NAME}" (see MIGRATION.md).`
+  );
+}

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -31,6 +31,11 @@ import {
   buildEnvironmentChanged,
   type DeploymentUrls,
 } from "./deployEnvironment.js";
+import {
+  componentNameCandidates,
+  legacyComponentNameWarning,
+  LEGACY_COMPONENT_NAME,
+} from "./componentName.js";
 
 function showHelp(): void {
   console.log(`
@@ -92,15 +97,47 @@ function tryFetchUrls(componentName: string): DeploymentUrls | null {
   }
 }
 
-function fetchUrls(componentName: string): DeploymentUrls {
-  const urls = tryFetchUrls(componentName);
-  if (!urls) {
+interface ResolvedComponent {
+  urls: DeploymentUrls;
+  componentName: string;
+}
+
+// The legacy-name warning is printed at most once per invocation.
+let warnedLegacyName = false;
+
+/**
+ * Resolve the deployment URLs and the instance name that answered. When the
+ * caller relied on the default name we also probe the legacy 0.1.x name, so a
+ * same-name migration keeps working without `--component selfHosting`. Returns
+ * null if no candidate is deployed yet (the caller may deploy the backend and
+ * retry).
+ */
+function tryResolveComponent(requested: string): ResolvedComponent | null {
+  for (const componentName of componentNameCandidates(requested)) {
+    const urls = tryFetchUrls(componentName);
+    if (urls) {
+      if (componentName === LEGACY_COMPONENT_NAME && !warnedLegacyName) {
+        console.warn(legacyComponentNameWarning(componentName));
+        warnedLegacyName = true;
+      }
+      return { urls, componentName };
+    }
+  }
+  return null;
+}
+
+function resolveComponentOrExit(requested: string): ResolvedComponent {
+  const resolved = tryResolveComponent(requested);
+  if (!resolved) {
+    const names = componentNameCandidates(requested)
+      .map((name) => `"${name}"`)
+      .join(" or ");
     console.error(
-      `Could not reach component "${componentName}". Deploy the Convex backend first (npx convex deploy) and ensure --component matches the name in convex.config.ts.`,
+      `Could not reach component ${names}. Deploy the Convex backend first (npx convex deploy) and ensure --component matches the name in convex.config.ts.`,
     );
     process.exit(1);
   }
-  return urls;
+  return resolved;
 }
 
 /**
@@ -155,7 +192,11 @@ async function main(): Promise<void> {
   console.log("");
   console.log("Step 1: Getting deployment URLs...");
 
-  let urls = tryFetchUrls(args.component);
+  let resolved = tryResolveComponent(args.component);
+  let urls = resolved?.urls ?? null;
+  // Falls back to the requested name until the backend is deployed and a real
+  // instance answers; re-resolved after each deploy below.
+  let componentName = resolved?.componentName ?? args.component;
   const shouldDeployBackend = !args.skipConvex;
   let backendAlreadyDeployed = false;
 
@@ -186,7 +227,9 @@ async function main(): Promise<void> {
         process.exit(1);
       }
 
-      urls = fetchUrls(args.component);
+      resolved = resolveComponentOrExit(args.component);
+      urls = resolved.urls;
+      componentName = resolved.componentName;
       console.log("");
       console.log(`   ✓ Site URL: ${urls.siteUrl}`);
       backendAlreadyDeployed = true;
@@ -231,7 +274,9 @@ async function main(): Promise<void> {
     console.log("");
     console.log("   ✓ Convex backend deployed");
 
-    const deployedUrls = fetchUrls(args.component);
+    const deployedComponent = resolveComponentOrExit(args.component);
+    const deployedUrls = deployedComponent.urls;
+    componentName = deployedComponent.componentName;
     if (!args.skipBuild) {
       if (!urls || buildEnvironmentChanged(urls, deployedUrls)) {
         console.log("");
@@ -270,9 +315,12 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // Pass the resolved instance name to the upload subprocess so it targets the
+  // same component (and doesn't re-probe or re-warn).
   const staticDeploySuccess = await uploadToConvexStorage({
     ...args,
     dist: distDir,
+    component: componentName,
   });
 
   if (!staticDeploySuccess) {
@@ -289,7 +337,7 @@ async function main(): Promise<void> {
   console.log(`✨ Deployment complete! (${duration}s)`);
   console.log("");
 
-  const finalUrls = urls ?? fetchUrls(args.component);
+  const finalUrls = urls ?? resolveComponentOrExit(args.component).urls;
   console.log(`Frontend: ${finalUrls.siteUrl}`);
 
   console.log("");

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -33,8 +33,8 @@ import {
 } from "./deployEnvironment.js";
 import {
   componentNameCandidates,
+  isLegacyAutoDetected,
   legacyComponentNameWarning,
-  LEGACY_COMPONENT_NAME,
 } from "./componentName.js";
 
 function showHelp(): void {
@@ -116,7 +116,7 @@ function tryResolveComponent(requested: string): ResolvedComponent | null {
   for (const componentName of componentNameCandidates(requested)) {
     const urls = tryFetchUrls(componentName);
     if (urls) {
-      if (componentName === LEGACY_COMPONENT_NAME && !warnedLegacyName) {
+      if (isLegacyAutoDetected(requested, componentName) && !warnedLegacyName) {
         console.warn(legacyComponentNameWarning(componentName));
         warnedLegacyName = true;
       }

--- a/src/cli/upload.ts
+++ b/src/cli/upload.ts
@@ -27,6 +27,11 @@ import {
   MAX_CONVEX_ARGUMENT_BYTES,
 } from "./argumentChunks.js";
 import { parseUploadArgs } from "./args.js";
+import {
+  componentNameCandidates,
+  legacyComponentNameWarning,
+  LEGACY_COMPONENT_NAME,
+} from "./componentName.js";
 
 // MIME type mapping
 const MIME_TYPES: Record<string, string> = {
@@ -106,26 +111,49 @@ interface DeploymentUrls {
 }
 
 /**
- * Resolve the component's deployment URLs. Bails the CLI if the component
- * isn't deployed. Uploading wouldn't work either, so a fallback would only
- * hide the real problem.
+ * Resolve the component's deployment URLs and the instance name that answered.
+ *
+ * When the caller relied on the default name we also probe the legacy 0.1.x
+ * name so a same-name migration keeps working without `--component selfHosting`
+ * on every command; landing on the legacy name prints a one-time warning. Bails
+ * the CLI if no candidate is deployed. Uploading wouldn't work either, so a
+ * fallback would only hide the real problem.
  */
-async function fetchUrls(componentName: string): Promise<DeploymentUrls> {
-  try {
-    const out = await convexRunAsync(componentName, "lib:getUrls");
-    return JSON.parse(out);
-  } catch {
-    console.error(
-      `Could not reach component "${componentName}". Deploy the Convex backend first and ensure --component matches the name in convex.config.ts.`,
-    );
-    process.exit(1);
+async function fetchUrls(
+  requested: string,
+): Promise<{ urls: DeploymentUrls; componentName: string }> {
+  const candidates = componentNameCandidates(requested);
+  for (const name of candidates) {
+    try {
+      const out = await convexRunAsync(
+        name,
+        "lib:getUrls",
+        {},
+        { quiet: true },
+      );
+      const urls: DeploymentUrls = JSON.parse(out);
+      if (name === LEGACY_COMPONENT_NAME) {
+        console.warn(legacyComponentNameWarning(name));
+      }
+      return { urls, componentName: name };
+    } catch {
+      // Try the next candidate name.
+    }
   }
+  console.error(
+    `Could not reach component ${candidates
+      .map((name) => `"${name}"`)
+      .join(" or ")}. Deploy the Convex backend first and ensure --component ` +
+      `matches the name in convex.config.ts.`,
+  );
+  process.exit(1);
 }
 
 function convexRunAsync(
   componentName: string | undefined,
   functionPath: string,
   args: Record<string, unknown> = {},
+  options: { quiet?: boolean } = {},
 ): Promise<string> {
   const serializedArgs = JSON.stringify(args);
   const argumentBytes = Buffer.byteLength(serializedArgs);
@@ -138,15 +166,18 @@ function convexRunAsync(
     );
   }
 
-  return runConvexAsync([
-    "run",
-    ...(componentName ? ["--component", componentName] : []),
-    functionPath,
-    serializedArgs,
-    "--typecheck=disable",
-    "--codegen=disable",
-    ...(useProd ? ["--prod"] : []),
-  ]);
+  return runConvexAsync(
+    [
+      "run",
+      ...(componentName ? ["--component", componentName] : []),
+      functionPath,
+      serializedArgs,
+      "--typecheck=disable",
+      "--codegen=disable",
+      ...(useProd ? ["--prod"] : []),
+    ],
+    options,
+  );
 }
 
 function errorMessage(error: unknown): string {
@@ -774,10 +805,12 @@ async function main(): Promise<void> {
 
   // The component knows both its CONVEX_SITE_URL (where the app is served,
   // including the mount prefix) and CONVEX_CLOUD_URL (what the frontend
-  // connects to). We fetch both in one call and trust neither hostname.
-  const { siteUrl: componentSiteUrl, cloudUrl: convexUrl } = await fetchUrls(
-    args.component,
-  );
+  // connects to). We fetch both in one call and trust neither hostname. This
+  // also resolves the instance name actually mounted (default or legacy).
+  const {
+    urls: { siteUrl: componentSiteUrl, cloudUrl: convexUrl },
+    componentName: resolvedComponentName,
+  } = await fetchUrls(args.component);
 
   // Run build if requested
   if (args.build) {
@@ -805,7 +838,7 @@ async function main(): Promise<void> {
   }
 
   const distDir = resolve(args.dist);
-  const componentName = args.component;
+  const componentName = resolvedComponentName;
   const useCdn = args.cdn;
 
   // Convex storage deployment

--- a/src/cli/upload.ts
+++ b/src/cli/upload.ts
@@ -29,8 +29,8 @@ import {
 import { parseUploadArgs } from "./args.js";
 import {
   componentNameCandidates,
+  isLegacyAutoDetected,
   legacyComponentNameWarning,
-  LEGACY_COMPONENT_NAME,
 } from "./componentName.js";
 
 // MIME type mapping
@@ -132,7 +132,7 @@ async function fetchUrls(
         { quiet: true },
       );
       const urls: DeploymentUrls = JSON.parse(out);
-      if (name === LEGACY_COMPONENT_NAME) {
+      if (isLegacyAutoDetected(requested, name)) {
         console.warn(legacyComponentNameWarning(name));
       }
       return { urls, componentName: name };


### PR DESCRIPTION
improve docs based on feedback, and fall back to old component name

only warn when it's a fallback